### PR TITLE
Add single quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,11 +24,12 @@
     const createScript = opts => {
       var boolOpts = '', textOpts = '', forceOpts = '' 
       opts.map(function (elem) {
+        console.log(elem.param);
         if(elem.param == '--force'){
             forceOpts += (elem.selected ? '--force' : '')
         }else{
             boolOpts += !elem.text ? elem.param + ' ' + (elem.selected ? 'yes' : 'no') + " " : ''
-            textOpts += elem.text && elem.text.length > 1 ? elem.param + ' ' + elem.text + ' ' : ''
+            textOpts += elem.text && elem.text.length > 1  ? elem.param + ' \'' + elem.text + '\' ' : ''
         }
       })
       return `sudo bash hst-install.sh ${boolOpts} ${textOpts} ${forceOpts} `

--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
     const createScript = opts => {
       var boolOpts = '', textOpts = '', forceOpts = '' 
       opts.map(function (elem) {
-        console.log(elem.param);
         if(elem.param == '--force'){
             forceOpts += (elem.selected ? '--force' : '')
         }else{


### PR DESCRIPTION
Should solve issues like: 

Morning All, a question I’ve used the script generator but the password switch seems to break the install. Should the password be surrounded with quotes as my password has symbols in it or should it be without them